### PR TITLE
Adapt markdown for gitlab remote repositories

### DIFF
--- a/git-usage-guide.md
+++ b/git-usage-guide.md
@@ -50,7 +50,7 @@ git config --list
 git init
 
 # 既存のリポジトリをクローン
-git clone https://github.com/username/repository.git
+git clone https://gitlab.com/namespace/project.git
 ```
 
 ## 基本的なGitコマンド
@@ -127,7 +127,7 @@ git branch -m old-name new-name
 ### リモートリポジトリの管理
 ```bash
 # リモートリポジトリを追加
-git remote add origin https://github.com/username/repository.git
+git remote add origin https://gitlab.com/namespace/project.git
 
 # リモートリポジトリの確認
 git remote -v


### PR DESCRIPTION
Update `git-usage-guide.md` to use GitLab examples for cloning and adding remote repositories.

---
<a href="https://cursor.com/background-agent?bcId=bc-315282a1-50f5-4d6d-ba82-63cfa79ce59d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-315282a1-50f5-4d6d-ba82-63cfa79ce59d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

